### PR TITLE
feat: add grill-me skill for stress-testing plans

### DIFF
--- a/ai/skills/grill-me/SKILL.md
+++ b/ai/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/claude-code.nix
+++ b/claude-code.nix
@@ -15,6 +15,7 @@ let
     adversarial-prd-review  = ./ai/skills/adversarial-prd-review;
     adversarial-rfc-review  = ./ai/skills/adversarial-rfc-review;
     worktrunk               = ./ai/skills/worktrunk;
+    grill-me                = ./ai/skills/grill-me;
   };
 in
 {

--- a/codex.nix
+++ b/codex.nix
@@ -13,6 +13,7 @@ let
     adversarial-code-review = ./ai/skills/adversarial-code-review;
     adversarial-prd-review  = ./ai/skills/adversarial-prd-review;
     adversarial-rfc-review  = ./ai/skills/adversarial-rfc-review;
+    grill-me                = ./ai/skills/grill-me;
   };
 
   # Agents (shared with Claude Code)


### PR DESCRIPTION
Adds the grill-me skill from mattpocock/skills, which interviews the
user about a plan or design until shared understanding is reached.

https://claude.ai/code/session_013vehv5CSD75DseiZJMkVKt