### PR TITLE
feat: add nvim-tree and claudecode.nvim plugins

### DIFF
--- a/neovim.nix
+++ b/neovim.nix
@@ -60,6 +60,13 @@ in
       telescope-nvim  # Fuzzy finder
       FTerm-nvim      # Floating terminal
 
+      # File explorer
+      nvim-tree-lua
+
+      # Claude Code integration
+      snacks-nvim     # required by claudecode-nvim
+      claudecode-nvim
+
       # Package management
       packer-nvim
     ];
@@ -70,6 +77,8 @@ in
       ./vim/cmp.lua
       ./vim/rustaceanvim.lua
       ./vim/cpp.lua
+      ./vim/nvim-tree.lua
+      ./vim/claudecode.lua
       ./vim/packer.lua
     ]);
   };

--- a/vim/claudecode.lua
+++ b/vim/claudecode.lua
@@ -1,0 +1,1 @@
+require('claudecode').setup()

--- a/vim/nvim-tree.lua
+++ b/vim/nvim-tree.lua
@@ -1,0 +1,18 @@
+-- Disable netrw before nvim-tree loads (recommended by upstream).
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
+require('nvim-tree').setup({
+  view = {
+    width = 35,
+  },
+  renderer = {
+    group_empty = true,
+  },
+  filters = {
+    dotfiles = false,
+  },
+})
+
+vim.keymap.set('n', '<F2>', '<CMD>NvimTreeToggle<CR>', { desc = 'Toggle nvim-tree' })
+vim.keymap.set('n', '<leader>e', '<CMD>NvimTreeFocus<CR>', { desc = 'Focus nvim-tree' })

--- a/vim/nvim-tree.lua
+++ b/vim/nvim-tree.lua
@@ -15,5 +15,5 @@ require('nvim-tree').setup({
   },
 })
 
-vim.keymap.set('n', '<F2>', '<CMD>NvimTreeToggle<CR>', { desc = 'Toggle nvim-tree' })
+vim.keymap.set('n', '<C-n>', '<CMD>NvimTreeToggle<CR>', { desc = 'Toggle nvim-tree' })
 vim.keymap.set('n', '<leader>e', '<CMD>NvimTreeFocus<CR>', { desc = 'Focus nvim-tree' })

--- a/vim/nvim-tree.lua
+++ b/vim/nvim-tree.lua
@@ -5,6 +5,7 @@ vim.g.loaded_netrwPlugin = 1
 require('nvim-tree').setup({
   view = {
     width = 35,
+    side = 'right',
   },
   renderer = {
     group_empty = true,


### PR DESCRIPTION
Wires nvim-tree-lua for a sidebar file explorer (toggle via <F2>,
focus via <leader>e) and claudecode-nvim for Claude Code integration,
along with its snacks-nvim runtime dependency.