### PR TITLE
Set neovim leader key to space

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -1,3 +1,7 @@
+" Set leader to space. Must come before any <leader> mappings load.
+let mapleader = " "
+let maplocalleader = " "
+
 "Use filename rather than full path in airline buffer list
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#fnamemod = ':t'


### PR DESCRIPTION
## Summary
- Sets `mapleader` and `maplocalleader` to space in `vim/vimrc`
- Space is far easier to reach than the default backslash and is the de-facto convention for modern neovim configs
- Placed at the top of the file so it takes effect before any `<leader>` mappings load (e.g. the `<leader>e` nvim-tree binding and claudecode's `<leader>a*` bindings)

## Test plan
- [ ] `home-manager switch` applies cleanly
- [ ] Press `<space>e` in neovim and confirm nvim-tree gains focus
- [ ] Press `<space>ac` and confirm the claudecode terminal toggles


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyXanwM7sU1BazjXxUcbKR)_