### PR TITLE
Wire claudecode.nvim keymaps with vim.keymap.set

### DIFF
--- a/vim/claudecode.lua
+++ b/vim/claudecode.lua
@@ -1,1 +1,11 @@
 require('claudecode').setup()
+
+vim.keymap.set('n', '<leader>ac', '<CMD>ClaudeCode<CR>',            { silent = true, desc = 'Toggle Claude terminal' })
+vim.keymap.set('n', '<leader>af', '<CMD>ClaudeCodeFocus<CR>',       { silent = true, desc = 'Focus Claude window' })
+vim.keymap.set('n', '<leader>ar', '<CMD>ClaudeCode --resume<CR>',   { silent = true, desc = 'Resume previous Claude session' })
+vim.keymap.set('n', '<leader>aC', '<CMD>ClaudeCode --continue<CR>', { silent = true, desc = 'Continue current Claude task' })
+vim.keymap.set('n', '<leader>am', '<CMD>ClaudeCodeSelectModel<CR>', { silent = true, desc = 'Select Claude model' })
+vim.keymap.set('n', '<leader>ab', '<CMD>ClaudeCodeAdd %<CR>',       { silent = true, desc = 'Add current buffer to Claude context' })
+vim.keymap.set('v', '<leader>as', '<CMD>ClaudeCodeSend<CR>',        { silent = true, desc = 'Send selection to Claude' })
+vim.keymap.set('n', '<leader>aa', '<CMD>ClaudeCodeDiffAccept<CR>',  { silent = true, desc = 'Accept Claude diff' })
+vim.keymap.set('n', '<leader>ad', '<CMD>ClaudeCodeDiffDeny<CR>',    { silent = true, desc = 'Reject Claude diff' })


### PR DESCRIPTION
## Summary
- Registers claudecode.nvim's suggested `<leader>a*` mappings explicitly with `vim.keymap.set`, since `claudecode.setup()` does not auto-bind them.
- Each mapping carries a `desc` so which-key surfaces them.

## Bindings

| Key | Mode | Command |
| --- | ---- | ------- |
| `<leader>ac` | n | `:ClaudeCode` |
| `<leader>af` | n | `:ClaudeCodeFocus` |
| `<leader>ar` | n | `:ClaudeCode --resume` |
| `<leader>aC` | n | `:ClaudeCode --continue` |
| `<leader>am` | n | `:ClaudeCodeSelectModel` |
| `<leader>ab` | n | `:ClaudeCodeAdd %` |
| `<leader>as` | v | `:ClaudeCodeSend` |
| `<leader>aa` | n | `:ClaudeCodeDiffAccept` |
| `<leader>ad` | n | `:ClaudeCodeDiffDeny` |

## Test plan
- [ ] `home-manager switch` applies cleanly
- [ ] In neovim, press `<space>a` and confirm which-key lists all entries above
- [ ] `<space>ac` opens the Claude terminal


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyXanwM7sU1BazjXxUcbKR)_