### PR TITLE
feat: add grill-with-docs skill for doc-aware grilling sessions

### DIFF
--- a/ai/skills/grill-with-docs/ADR-FORMAT.md
+++ b/ai/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/ai/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/ai/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,63 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/ai/skills/grill-with-docs/SKILL.md
+++ b/ai/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/claude-code.nix
+++ b/claude-code.nix
@@ -16,6 +16,7 @@ let
     adversarial-rfc-review  = ./ai/skills/adversarial-rfc-review;
     worktrunk               = ./ai/skills/worktrunk;
     grill-me                = ./ai/skills/grill-me;
+    grill-with-docs         = ./ai/skills/grill-with-docs;
   };
 in
 {

--- a/codex.nix
+++ b/codex.nix
@@ -14,6 +14,7 @@ let
     adversarial-prd-review  = ./ai/skills/adversarial-prd-review;
     adversarial-rfc-review  = ./ai/skills/adversarial-rfc-review;
     grill-me                = ./ai/skills/grill-me;
+    grill-with-docs         = ./ai/skills/grill-with-docs;
   };
 
   # Agents (shared with Claude Code)

--- a/cursor.nix
+++ b/cursor.nix
@@ -1,0 +1,59 @@
+{ config, pkgs, lib, ... }:
+let
+  # Skills exposed as Cursor Rules under ~/.cursor/rules/<name>/
+  # Each skill's SKILL.md is converted to <name>.mdc with Cursor frontmatter
+  # (description + alwaysApply: false → manual invocation via @<name>).
+  # Sibling files in the skill directory are copied verbatim so relative
+  # links from the SKILL.md (e.g. ./CONTEXT-FORMAT.md) still resolve.
+  skillsToCopy = {
+    grill-with-docs = ./ai/skills/grill-with-docs;
+  };
+
+  # Convert a Claude-style SKILL.md (YAML frontmatter with name+description)
+  # into a Cursor .mdc rule (description + alwaysApply: false).
+  skillToCursorRule = name: skillDir: pkgs.runCommand "${name}.mdc" {
+    nativeBuildInputs = [ pkgs.gawk ];
+  } ''
+    src=${skillDir}/SKILL.md
+
+    desc=$(${pkgs.gawk}/bin/awk '
+      /^---$/ { count++; next }
+      count == 1 && /^description:/ {
+        sub(/^description:[[:space:]]*/, "")
+        print
+        exit
+      }
+    ' "$src")
+
+    body=$(${pkgs.gawk}/bin/awk '
+      /^---$/ { count++; next }
+      count >= 2 { print }
+    ' "$src")
+
+    {
+      echo "---"
+      echo "description: $desc"
+      echo "alwaysApply: false"
+      echo "---"
+      echo ""
+      echo "$body"
+    } > $out
+  '';
+in
+{
+  # Copy skill bundles to ~/.cursor/rules/<name>/ and write the rule file.
+  # Done via activation (not home.file) so we can drop the whole directory
+  # tree from the Nix store and keep referenced files (e.g. ADR-FORMAT.md)
+  # alongside the .mdc rule.
+  home.activation.copyCursorSkills = lib.hm.dag.entryAfter ["writeBoundary"] ''
+    mkdir -p $HOME/.cursor/rules
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: path: ''
+      rm -rf $HOME/.cursor/rules/${name}
+      cp -rL ${path} $HOME/.cursor/rules/${name}
+      chmod -R u+w $HOME/.cursor/rules/${name}
+      cp -L ${skillToCursorRule name path} $HOME/.cursor/rules/${name}/${name}.mdc
+      chmod u+w $HOME/.cursor/rules/${name}/${name}.mdc
+      rm -f $HOME/.cursor/rules/${name}/SKILL.md
+    '') skillsToCopy)}
+  '';
+}

--- a/custom-shell.nix
+++ b/custom-shell.nix
@@ -96,5 +96,7 @@ in
       claudeToGemini "adversarial-prd-review" "Adversarial review of PRDs and product specs" ./ai/skills/adversarial-prd-review/SKILL.md;
     ".gemini/commands/adversarial-rfc-review.toml".source =
       claudeToGemini "adversarial-rfc-review" "Adversarial review of RFCs and technical design documents" ./ai/skills/adversarial-rfc-review/SKILL.md;
+    ".gemini/commands/grill-with-docs.toml".source =
+      claudeToGemini "grill-with-docs" "Grilling session that stress-tests a plan against the project's CONTEXT.md glossary and updates ADRs inline" ./ai/skills/grill-with-docs/SKILL.md;
   };
 }

--- a/home.nix
+++ b/home.nix
@@ -6,6 +6,7 @@ let
     ./custom-shell.nix
     ./claude-code.nix
     ./codex.nix
+    ./cursor.nix
     ./starship.nix
     ./neovim.nix
     ./tmux.nix


### PR DESCRIPTION
Vendored from mattpocock/skills@main:skills/engineering/grill-with-docs.
Extends grill-me by challenging plans against CONTEXT.md glossary and
updating ADRs/CONTEXT.md inline as decisions crystallise.